### PR TITLE
Introducing autocomplete from Angular Material

### DIFF
--- a/src/NuGetTrends.Spa/package.json
+++ b/src/NuGetTrends.Spa/package.json
@@ -13,10 +13,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^8.1.1",
+    "@angular/cdk": "^8.1.1",
     "@angular/common": "^8.1.1",
     "@angular/compiler": "^8.1.1",
     "@angular/core": "^8.1.1",
     "@angular/forms": "^8.1.1",
+    "@angular/material": "^8.1.1",
     "@angular/platform-browser": "^8.1.1",
     "@angular/platform-browser-dynamic": "^8.1.1",
     "@angular/router": "^8.1.1",

--- a/src/NuGetTrends.Spa/src/app/shared/components/search-input/search-input.component.html
+++ b/src/NuGetTrends.Spa/src/app/shared/components/search-input/search-input.component.html
@@ -1,32 +1,23 @@
-<section class="filter-wrapper">
-  <div class="keyword-wrapper control" [ngClass]="{'is-large is-loading' : isSearching}">
+<section>
+  <div matAutocompleteOrigin
+       #origin="matAutocompleteOrigin"
+       class="control"
+       [ngClass]="{'is-large is-loading' : isSearching}">
     <input
-      autofocus
       class="input is-large"
       type="text"
-      placeholder="Start typing to discover NuGet Trends"
       #searchBox
+      placeholder="Start typing to discover NuGet Trends"
       [formControl]="queryField"
-      (keydown)="focusElementAndCheckForResults()"
-      />
-    <span class="icon is-medium is-left">
-      <i class="fa fa-search"></i>
-    </span>
+      [matAutocomplete]="auto"
+      [matAutocompleteConnectedTo]="origin">
+    <span class="icon is-medium is-left"><i class="fa fa-search"></i></span>
   </div>
-  <ul class="filter-select" #container *ngIf="showResults">
-    <li *ngFor="let package of results$ | async" class="filter-select-list" (click)="searchItemSelected(package.packageId)">
-      <article class="media" >
-        <figure class="media-left">
-          <p class="image is-32x32">
-              <img src="{{package.iconUrl}}"
-                   onerror="this.onerror=null;this.src='https://nuget.org/Content/Images/packageDefaultIcon-50x50.png';" />
-          </p>
-        </figure>
-        <div class="media-content is-pulled-left">
-          <div class="content">
-            <p>{{package.packageId}}</p>
-          </div>
-        </div>
-      </article>
-  </ul>
+  <mat-autocomplete #auto="matAutocomplete" (optionSelected)='searchItemSelected($event)'>
+    <mat-option *ngFor="let package of results$ | async" [value]="package.packageId">
+      <img class="package-img" src="{{package.iconUrl}}"
+           onerror="this.onerror=null;this.src='https://nuget.org/Content/Images/packageDefaultIcon-50x50.png';"/>
+      <span>{{package.packageId}}</span>
+    </mat-option>
+  </mat-autocomplete>
 </section>

--- a/src/NuGetTrends.Spa/src/app/shared/components/search-input/search-input.component.scss
+++ b/src/NuGetTrends.Spa/src/app/shared/components/search-input/search-input.component.scss
@@ -1,64 +1,24 @@
 @import '../../../../colors';
 
-.filter-wrapper {
-  position: relative;
-}
-.keyword-wrapper {
-  width: 100%;
-  position: relative;
-}
-
-#keyword {
-  border: 1px solid #ccc;
-  padding: 10px;
-  font: 1.5em 'Arimo', sans-serif;
-  width: 50%;
-  outline: none;
-  transition: border 0.5s ease-in-out
-}
-#keyword:focus {
-  border-color : rgba(81, 203, 238, 1);;
-}
-#keyword-button {
-  position: absolute;
-  right: 26%;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 1.7em;
-  color: #8DB9ED
-}
-#keyword-button:hover {
-  color: #ccc
-}
-.filter-select {
-  list-style: none;
+.mat-autocomplete-panel {
   font-size: 1.1em;
   color: $grey-dark;
   border: 1px solid $grey-light;
   border-top: none;
-  width: 100%;
-  position: absolute;
-  z-index: 999;
-  max-height: 300px;
-  overflow-y: auto;
-  background: $white-ter
-}
-.filter-select-list img {
-  margin-left: 5px;
-}
-.filter-select-list {
-  cursor: pointer;
-  padding: 10px 1px;
-}
-.artist-name {
-  display: inline-block;
-  //position: absolute;
-}
-.filter-select-list:hover {
-  background:  $cyan;
-  color: #fff
+  background-color: $white-ter
 }
 
+.package-img {
+  max-height: 32px;
+  vertical-align: middle;
+  margin-right: 8px;
+}
+
+.mat-option:hover:not(.mat-option-disabled),
+.mat-option.mat-active {
+  background-color: $cyan;
+  color: #fff
+}
 
 /* Extra styles to make the input a little nicer on the header */
 input:focus{

--- a/src/NuGetTrends.Spa/src/app/shared/shared.module.ts
+++ b/src/NuGetTrends.Spa/src/app/shared/shared.module.ts
@@ -1,18 +1,20 @@
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {ToastrModule} from 'ngx-toastr';
 
 import {SearchInputComponent} from './components/search-input/search-input.component';
 import {PackageListComponent} from './components/package-list/package-list.component';
-import { SearchTypeComponent } from './components/search-type/search-type.component';
+import {SearchTypeComponent} from './components/search-type/search-type.component';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import { SearchPeriodComponent } from './components/search-period/search-period.component';
+import {SearchPeriodComponent} from './components/search-period/search-period.component';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
+    MatAutocompleteModule,
     ToastrModule.forRoot({
       positionClass: 'toast-bottom-right',
       preventDuplicates: true,
@@ -29,6 +31,7 @@ import { SearchPeriodComponent } from './components/search-period/search-period.
   exports: [
     CommonModule,
     FormsModule,
+    MatAutocompleteModule,
     ReactiveFormsModule,
     SearchInputComponent,
     PackageListComponent,

--- a/src/NuGetTrends.Spa/src/styles.scss
+++ b/src/NuGetTrends.Spa/src/styles.scss
@@ -3,6 +3,7 @@ $fa-font-path: "../node_modules/font-awesome/fonts";
 @import "../node_modules/font-awesome/scss/font-awesome.scss";
 
 /* Bulma Color Overrides*/
+@import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
 @import './colors';
 @import '../node_modules/bulma/bulma.sass';
 

--- a/src/NuGetTrends.Spa/yarn.lock
+++ b/src/NuGetTrends.Spa/yarn.lock
@@ -103,6 +103,14 @@
   dependencies:
     tslib "^1.9.0"
 
+"@angular/cdk@^8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-8.1.1.tgz#11b11bbab7316b3fa1f9eb380211bfde0a335cc7"
+  dependencies:
+    tslib "^1.7.1"
+  optionalDependencies:
+    parse5 "^5.0.0"
+
 "@angular/cli@~8.1.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-8.1.1.tgz#c63e525c74046457f07d35cb3ec66818c8c6d7b1"
@@ -169,6 +177,12 @@
 "@angular/language-service@^8.1.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-8.1.1.tgz#5940b764fa395b75acd50777721c0aa2914e58c9"
+
+"@angular/material@^8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-8.1.1.tgz#87e105fb657fa6e139ddcbd6b9c373936604f6d7"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/platform-browser-dynamic@^8.1.1":
   version "8.1.1"
@@ -4268,6 +4282,10 @@ parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
+parse5@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+
 parseqs@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
@@ -5663,7 +5681,7 @@ ts-node@8.3.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
 


### PR DESCRIPTION
Switched from using a custom "autocomplete" component to using the Angular Material [`autocomplete`](https://material.angular.io/components/autocomplete/overview) one.

The motivation was to add keyboard navigation support, which turned out to be a nightmare to implement it. I looked what the angular one does and it has everything we need for now.

Closes #6 - Keyboard navigation and selection works (ENTER, UP and DOWN)
Closes #44 - I think now the input is being focused, at least when the page loads. It's tricky when routing happens though
