### PR TITLE
Fixed package logo size in the search box

### DIFF
--- a/src/NuGetTrends.Spa/src/app/shared/components/search-input/search-input.component.scss
+++ b/src/NuGetTrends.Spa/src/app/shared/components/search-input/search-input.component.scss
@@ -9,7 +9,8 @@
 }
 
 .package-img {
-  max-height: 32px;
+  height: 32px;
+  width: 32px;  
   vertical-align: middle;
   margin-right: 8px;
 }


### PR DESCRIPTION
After moving to autocomplete from angular, some CSS classes were removed/changed. Now, when the package does not have an icon, it displays the fallback image like this:

![image](https://user-images.githubusercontent.com/5938087/61613626-217b1e00-ac62-11e9-84ee-868013b06e55.png)

Limiting again the size of the icons in our styles (before it was using Bulma helper classes).