### PR TITLE
Changed Azure Pipelines status badge to the master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 | Component | Status |
 |-----------|--------|
-| NuGet Trends API | [![Build Status](https://dev.azure.com/nugettrends/nuget-trends/_apis/build/status/NuGetTrends%20-%20API?branchName=develop)](https://dev.azure.com/nugettrends/nuget-trends/_build/latest?definitionId=2&branchName=master) |
-| NuGet Trends Worker | [![Build Status](https://dev.azure.com/nugettrends/nuget-trends/_apis/build/status/NuGetTrends%20-%20Worker?branchName=develop)](https://dev.azure.com/nugettrends/nuget-trends/_build/latest?definitionId=5&branchName=master) |
+| NuGet Trends API | [![Build Status](https://dev.azure.com/nugettrends/nuget-trends/_apis/build/status/NuGetTrends%20-%20API?branchName=master)](https://dev.azure.com/nugettrends/nuget-trends/_build/latest?definitionId=2&branchName=master) |
+| NuGet Trends Worker | [![Build Status](https://dev.azure.com/nugettrends/nuget-trends/_apis/build/status/NuGetTrends%20-%20Worker?branchName=master)](https://dev.azure.com/nugettrends/nuget-trends/_build/latest?definitionId=5&branchName=master) |
 | NuGet Trends SPA | - |
 
 ## Developing


### PR DESCRIPTION
When I introduced the builds on Azure DevOps, I used the `develop` branch as the target for the status badge on `README.md`. We decided to remove the `develop` branch, but the status badge was still pointing to it, thus showing "Never built".

I simply triggered a new build and generated the badge now for `master`.